### PR TITLE
Rename qlxad -> quantlib-xad

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -53,7 +53,7 @@ jobs:
         path: XAD
     - uses: actions/checkout@v3
       with:
-        path: qlxad
+        path: quantlib-xad
     - name: Setup
       run: |
         sudo apt update
@@ -68,7 +68,7 @@ jobs:
         cd QuantLib
         mkdir build
         cd build
-        cmake -G Ninja -DBOOST_ROOT=/usr -DQLXAD_DISABLE_AAD=${{ matrix.disable_aad }} -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DQL_EXTERNAL_SUBDIRECTORIES="${{ github.workspace }}/XAD;${{ github.workspace }}/qlxad" -DQL_EXTRA_LINK_LIBRARIES=qlxad -DQL_NULL_AS_FUNCTIONS=ON ..
+        cmake -G Ninja -DBOOST_ROOT=/usr -DQLXAD_DISABLE_AAD=${{ matrix.disable_aad }} -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DQL_EXTERNAL_SUBDIRECTORIES="${{ github.workspace }}/XAD;${{ github.workspace }}/quantlib-xad" -DQL_EXTRA_LINK_LIBRARIES=quantlib-xad -DQL_NULL_AS_FUNCTIONS=ON ..
     - name: Compile
       run: |
         cd QuantLib/build
@@ -77,11 +77,11 @@ jobs:
       run: |
         cd QuantLib/build
         ./test-suite/quantlib-test-suite --log_level=message    
-    - name: Test QlXAD
+    - name: Test quantlib-xad
       if: ${{ matrix.disable_aad == 'OFF' }}
       run: |
         cd QuantLib/build
-        ./qlxad/test-suite/quantlib-xad-test-suite --log_level=message
+        ./quantlib-xad/test-suite/quantlib-xad-test-suite --log_level=message
 
 
   xad-win:
@@ -105,7 +105,7 @@ jobs:
         path: XAD
     - uses: actions/checkout@v3
       with:
-        path: qlxad
+        path: quantlib-xad
     - name: sccache
       uses: hendrikmuhs/ccache-action@v1.2.5
       with:
@@ -127,7 +127,7 @@ jobs:
         mkdir build
         cd build
         call "${{ env.vsvarsall }}" amd64 -vcvars_ver=14.3
-        cmake .. -G Ninja -DQLXAD_DISABLE_AAD=${{ matrix.disable_aad }} -DCMAKE_CXX_COMPILER_LAUNCHER=sccache -DCMAKE_BUILD_TYPE=Release -DQL_EXTERNAL_SUBDIRECTORIES="${{ github.workspace }}/XAD;${{ github.workspace }}/qlxad" -DQL_EXTRA_LINK_LIBRARIES=qlxad -DQL_NULL_AS_FUNCTIONS=ON -DXAD_STATIC_MSVC_RUNTIME=ON
+        cmake .. -G Ninja -DQLXAD_DISABLE_AAD=${{ matrix.disable_aad }} -DCMAKE_CXX_COMPILER_LAUNCHER=sccache -DCMAKE_BUILD_TYPE=Release -DQL_EXTERNAL_SUBDIRECTORIES="${{ github.workspace }}/XAD;${{ github.workspace }}/quantlib-xad" -DQL_EXTRA_LINK_LIBRARIES=quantlib-xad -DQL_NULL_AS_FUNCTIONS=ON -DXAD_STATIC_MSVC_RUNTIME=ON
     - name: Build
       shell: cmd
       run: |
@@ -140,13 +140,13 @@ jobs:
         cd QuantLib\build
         call "${{ env.vsvarsall }}" amd64 -vcvars_ver=14.3
         .\test-suite\quantlib-test-suite --log_level=message
-    - name: Test QlXAD
+    - name: Test quantlib-xad
       if: ${{ matrix.disable_aad == 'OFF' }}
       shell: cmd
       run: |
         cd QuantLib\build
         call "${{ env.vsvarsall }}" amd64 -vcvars_ver=14.3
-        .\qlxad\test-suite\quantlib-xad-test-suite --log_level=message
+        .\quantlib-xad\test-suite\quantlib-xad-test-suite --log_level=message
 
 
   xad-macos:
@@ -170,7 +170,7 @@ jobs:
         path: XAD
     - uses: actions/checkout@v3
       with:
-        path: qlxad
+        path: quantlib-xad
     - name: Setup
       run: |
         brew install boost
@@ -186,7 +186,7 @@ jobs:
         cd QuantLib
         mkdir build
         cd build
-        cmake -G Ninja -DBOOST_ROOT=/usr -DQLXAD_DISABLE_AAD=${{ matrix.disable_aad }} -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DQL_EXTERNAL_SUBDIRECTORIES="${{ github.workspace }}/XAD;${{ github.workspace }}/qlxad" -DQL_EXTRA_LINK_LIBRARIES=qlxad -DQL_NULL_AS_FUNCTIONS=ON ..
+        cmake -G Ninja -DBOOST_ROOT=/usr -DQLXAD_DISABLE_AAD=${{ matrix.disable_aad }} -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DQL_EXTERNAL_SUBDIRECTORIES="${{ github.workspace }}/XAD;${{ github.workspace }}/quantlib-xad" -DQL_EXTRA_LINK_LIBRARIES=quantlib-xad -DQL_NULL_AS_FUNCTIONS=ON ..
     - name: Compile
       run: |
         cd QuantLib/build
@@ -195,8 +195,8 @@ jobs:
       run: |
         cd QuantLib/build
         ./test-suite/quantlib-test-suite --log_level=message    
-    - name: Test QlXAD
+    - name: Test quantlib-xad
       if: ${{ matrix.disable_aad == 'OFF' }}
       run: |
         cd QuantLib/build
-        ./qlxad/test-suite/quantlib-xad-test-suite --log_level=message
+        ./quantlib-xad/test-suite/quantlib-xad-test-suite --log_level=message

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-All notable changes to the qlxad module will be documented in this file.
+All notable changes to the quantlib-xad module will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
@@ -28,8 +28,8 @@ Note that we follow QuantLib's releases in this repository, with matching versio
 Initial open-source release, compatible with [QuantLib v1.28](https://github.com/lballabio/QuantLib/releases/tag/QuantLib-v1.28).
 
 
-[unreleased]: https://github.com/auto-differentiation/qlxad/compare/v1.28...HEAD
+[unreleased]: https://github.com/auto-differentiation/quantlib-xad/compare/v1.28...HEAD
 
-[1.28]: https://github.com/auto-differentiation/qlxad/tree/v1.28
+[1.28]: https://github.com/auto-differentiation/quantlib-xad/tree/v1.28
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 ##############################################################################
 #   
 #
-#  This file is part of qlxad, an adaptor module to enable using XAD with
+#  This file is part of quantlib-xad, an adaptor module to enable using XAD with
 #  QuantLib. XAD is a fast and comprehensive C++ library for
 #  automatic differentiation.
 #

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ by our [code of conduct](CODE_OF_CONDUCT.md).
 1.  Fork, then clone the repository:
 
 ```bash
-git clone https://github.com/yourusername/qlxad.git
+git clone https://github.com/yourusername/quantlib-xad.git
 ```
 
 2.  Follow the [Build Instructions](README.md) to setup the dependencies and 
@@ -53,6 +53,6 @@ accepted:
 
 This repository follows [QuantLib's coding style](https://www.quantlib.org/style.shtml).
 
-[pr]: https://github.com/auto-differentiation/qlxad/compare/
+[pr]: https://github.com/auto-differentiation/quantlib-xad/compare/
 
 [cla]: https://gist.github.com/xcelerit-dev/ee51f6c0a3365ae2fc2489e092366de2

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # QuantLib - XAD Integration Repository
 
 <p align="center" dir="auto">
-    <a href="https://github.com/auto-differentiation/qlxad/actions/workflows/ci.yaml">
-        <img src="https://img.shields.io/github/actions/workflow/status/auto-differentiation/qlxad/ci.yaml?label=Build%20%28XAD%20main%20vs%20QuantLib%20master%29" alt="GitHub Workflow Status" style="max-width: 100%;margin-right:20px">
+    <a href="https://github.com/auto-differentiation/quantlib-xad/actions/workflows/ci.yaml">
+        <img src="https://img.shields.io/github/actions/workflow/status/auto-differentiation/quantlib-xad/ci.yaml?label=Build%20%28XAD%20main%20vs%20QuantLib%20master%29" alt="GitHub Workflow Status" style="max-width: 100%;margin-right:20px">
     </a>
-    <a href="https://github.com/auto-differentiation/qlxad/blob/main/CONTRIBUTING.md">
+    <a href="https://github.com/auto-differentiation/quantlib-xad/blob/main/CONTRIBUTING.md">
         <img src="https://img.shields.io/badge/PRs%20-welcome-brightgreen.svg" alt="PRs Welcome" style="max-width: 100%;">
     </a>
 </p>
@@ -24,9 +24,9 @@ For detailed build instructions with [XAD](https://auto-differentiation.github.i
 
 ## Getting Help
 
-If you have found an issue, want to report a bug, or have a feature request, please raise a [GitHub issue](https://github.com/auto-differentiation/qlxad/issues).
+If you have found an issue, want to report a bug, or have a feature request, please raise a [GitHub issue](https://github.com/auto-differentiation/quantlib-xad/issues).
 
-For general questions about XAD, sharing ideas, engaging with community members, etc, please use [GitHub Discussions](https://github.com/auto-differentiation/qlxad/discussions).
+For general questions about XAD, sharing ideas, engaging with community members, etc, please use [GitHub Discussions](https://github.com/auto-differentiation/quantlib-xad/discussions).
 
 
 ## Contributing
@@ -42,7 +42,7 @@ Please also obey our [Code of Conduct](CODE_OF_CONDUCT.md) in all communication.
 ## Authors
 
 -   Various contributors from Xcelerit
--   See also the list of [contributors](https://github.com/auto-differentiation/qlxad/contributors) who participated in the project.
+-   See also the list of [contributors](https://github.com/auto-differentiation/quantlib-xad/contributors) who participated in the project.
 
 
 ## License

--- a/ql/CMakeLists.txt
+++ b/ql/CMakeLists.txt
@@ -1,7 +1,7 @@
 ##############################################################################
 #   
 #
-#  This file is part of qlxad, an adaptor module to enable using XAD with
+#  This file is part of quantlib-xad, an adaptor module to enable using XAD with
 #  QuantLib. XAD is a fast and comprehensive C++ library for
 #  automatic differentiation.
 #
@@ -25,24 +25,24 @@
 set(QLXAD_HEADERS
     qlxad.hpp
 )
-add_library(qlxad INTERFACE)
-target_include_directories(qlxad INTERFACE
+add_library(quantlib-xad INTERFACE)
+target_include_directories(quantlib-xad INTERFACE
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/..>
     $<INSTALL_INTERFACE:${QL_INSTALL_INCLUDEDIR}>
 )
 if(NOT QLXAD_DISABLE_AAD)
-    target_compile_definitions(qlxad INTERFACE QL_INCLUDE_FIRST=ql/qlxad.hpp)
+    target_compile_definitions(quantlib-xad INTERFACE QL_INCLUDE_FIRST=ql/qlxad.hpp)
 else()
-    target_compile_definitions(qlxad INTERFACE QLXAD_DISABLE_AAD=1)
+    target_compile_definitions(quantlib-xad INTERFACE QLXAD_DISABLE_AAD=1)
 endif()
 if(MSVC)
-    target_compile_options(qlxad INTERFACE /bigobj)
+    target_compile_options(quantlib-xad INTERFACE /bigobj)
 endif()
-target_link_libraries(qlxad INTERFACE XAD::xad)
-set_target_properties(qlxad PROPERTIES
+target_link_libraries(quantlib-xad INTERFACE XAD::xad)
+set_target_properties(quantlib-xad PROPERTIES
     EXPORT_NAME ${PACKAGE_NAME}
 )
-install(TARGETS qlxad EXPORT QlXadTargets)
+install(TARGETS quantlib-xad EXPORT QlXadTargets)
 foreach(file ${QLXAD_HEADERS})
     install(FILES ${file} DESTINATION "${QL_INSTALL_INCLUDEDIR}/ql")
 endforeach()

--- a/ql/qlxad.hpp
+++ b/ql/qlxad.hpp
@@ -1,6 +1,6 @@
 /*******************************************************************************
 
-   This file is part of qlxad, an adaptor module to enable using XAD with
+   This file is part of quantlib-xad, an adaptor module to enable using XAD with
    QuantLib. XAD is a fast and comprehensive C++ library for
    automatic differentiation.
 

--- a/test-suite/CMakeLists.txt
+++ b/test-suite/CMakeLists.txt
@@ -28,17 +28,17 @@ set(QLXAD_TEST_HEADERS
 )
 
 if(QL_BUILD_TEST_SUITE)
-    add_executable(qlxad_test_suite ${QLXAD_TEST_SOURCES} ${QLXAD_TEST_HEADERS})
-    set_target_properties(qlxad_test_suite PROPERTIES OUTPUT_NAME "quantlib-xad-test-suite")
+    add_executable(quantlib-xad_test_suite ${QLXAD_TEST_SOURCES} ${QLXAD_TEST_HEADERS})
+    set_target_properties(quantlib-xad_test_suite PROPERTIES OUTPUT_NAME "quantlib-xad-test-suite")
     if (NOT Boost_USE_STATIC_LIBS)
-        target_compile_definitions(qlxad_test_suite PRIVATE BOOST_ALL_DYN_LINK BOOST_TEST_DYN_LINK)
+        target_compile_definitions(quantlib-xad_test_suite PRIVATE BOOST_ALL_DYN_LINK BOOST_TEST_DYN_LINK)
     endif()
-    target_link_libraries(qlxad_test_suite PRIVATE
+    target_link_libraries(quantlib-xad_test_suite PRIVATE
         ql_library
         ql_unit_test_main
         ${QL_THREAD_LIBRARIES})
     if (QL_INSTALL_TEST_SUITE)
-        install(TARGETS qlxad_test_suite RUNTIME DESTINATION ${QL_INSTALL_BINDIR})
+        install(TARGETS quantlib-xad_test_suite RUNTIME DESTINATION ${QL_INSTALL_BINDIR})
     endif()
-    add_test(NAME quantlib_xad_test_suite COMMAND qlxad_test_suite --log_level=message)
+    add_test(NAME quantlib-xad_test_suite COMMAND quantlib-xad_test_suite --log_level=message)
 endif()


### PR DESCRIPTION
This PR renames the various resources and docs from qlxad to quantlib-xad, after the repository has been renamed.