### PR TITLE
Prepare release 1.31

### DIFF
--- a/presets/CMakeUserPresets-1.31.json
+++ b/presets/CMakeUserPresets-1.31.json
@@ -1,0 +1,286 @@
+{
+  "version": 3,
+  "configurePresets": [
+    {
+      "name": "xad-base",
+      "hidden": true,
+      "cacheVariables": {
+        "QL_EXTERNAL_SUBDIRECTORIES": "${sourceDir}/../XAD;${sourceDir}/../quantlib-xad",
+        "QL_EXTRA_LINK_LIBRARIES": "quantlib-xad",
+        "QL_NULL_AS_FUNCTIONS": "ON",
+        "XAD_STATIC_MSVC_RUNTIME": "ON",
+        "QLXAD_DISABLE_AAD": "OFF"
+      }
+    },
+    {
+      "name": "windows-base",
+      "hidden": true,
+      "binaryDir": "${sourceDir}/build/${presetName}",
+      "architecture": {
+        "value": "x64",
+        "strategy": "external"
+      },
+      "condition": {
+        "type": "equals",
+        "lhs": "${hostSystemName}",
+        "rhs": "Windows"
+      }
+    },
+    {
+      "name": "windows-msvc-base",
+      "hidden": true,
+      "inherits": "windows-base",
+      "cacheVariables": {
+        "CMAKE_CXX_COMPILER": "cl.exe"
+      },
+      "vendor": {
+        "microsoft.com/VisualStudioSettings/CMake/1.0": {
+          "intelliSenseMode": "windows-msvc-x64"
+        }
+      }
+    },
+    {
+      "name": "windows-clang-base",
+      "hidden": true,
+      "inherits": "windows-base",
+      "cacheVariables": {
+        "CMAKE_CXX_COMPILER": "clang-cl.exe"
+      },
+      "vendor": {
+        "microsoft.com/VisualStudioSettings/CMake/1.0": {
+          "intelliSenseMode": "windows-clang-x64"
+        }
+      }
+    },
+    {
+      "name": "linux-base",
+      "hidden": true,
+      "binaryDir": "${sourceDir}/build/${presetName}",
+      "condition": {
+        "type": "equals",
+        "lhs": "${hostSystemName}",
+        "rhs": "Linux"
+      },
+      "vendor": {
+        "microsoft.com/VisualStudioRemoteSettings/CMake/1.0": {
+          "sourceDir": "$env{HOME}/.vs/$ms{projectDirName}"
+        },
+        "microsoft.com/VisualStudioSettings/CMake/1.0": {
+          "intelliSenseMode": "linux-gcc-x64",
+          "hostOS": [
+            "Linux"
+          ]
+        }
+      }
+    },
+    {
+      "name": "linux-gcc-base",
+      "hidden": true,
+      "inherits": "linux-base",
+      "cacheVariables": {
+        "CMAKE_CXX_COMPILER": "g++"
+      }
+    },
+    {
+      "name": "linux-clang-base",
+      "hidden": true,
+      "inherits": "linux-base",
+      "cacheVariables": {
+        "CMAKE_CXX_COMPILER": "clang++"
+      }
+    },
+    {
+      "name": "ninja",
+      "hidden": true,
+      "generator": "Ninja"
+    },
+    {
+      "name": "make",
+      "hidden": true,
+      "generator": "Unix Makefiles"
+    },
+    {
+      "name": "release",
+      "hidden": true,
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Release"
+      }
+    },
+    {
+      "name": "debug",
+      "hidden": true,
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug"
+      }
+    },
+    {
+      "name": "relwithdebinfo",
+      "hidden": true,
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "RelWithDebInfo"
+      }
+    },
+    {
+      "name": "linux-xad-clang-debug",
+      "inherits": [
+        "linux-clang-base",
+        "make",
+        "debug",
+        "xad-base"
+      ]
+    },
+    {
+      "name": "linux-xad-clang-release",
+      "inherits": [
+        "linux-clang-base",
+        "make",
+        "release",
+        "xad-base"
+      ]
+    },
+    {
+      "name": "linux-xad-clang-relwithdebinfo",
+      "inherits": [
+        "linux-clang-base",
+        "make",
+        "relwithdebinfo",
+        "xad-base"
+      ]
+    },
+    {
+      "name": "linux-xad-gcc-debug",
+      "inherits": [
+        "linux-gcc-base",
+        "make",
+        "debug",
+        "xad-base"
+      ]
+    },
+    {
+      "name": "linux-xad-gcc-release",
+      "inherits": [
+        "linux-gcc-base",
+        "make",
+        "release",
+        "xad-base"
+      ]
+    },
+    {
+      "name": "linux-xad-gcc-relwithdebinfo",
+      "inherits": [
+        "linux-gcc-base",
+        "make",
+        "relwithdebinfo",
+        "xad-base"
+      ]
+    },
+    {
+      "name": "linux-xad-clang-ninja-debug",
+      "inherits": [
+        "linux-clang-base",
+        "ninja",
+        "debug",
+        "xad-base"
+      ]
+    },
+    {
+      "name": "linux-xad-clang-ninja-release",
+      "inherits": [
+        "linux-clang-base",
+        "ninja",
+        "release",
+        "xad-base"
+      ]
+    },
+    {
+      "name": "linux-xad-clang-ninja-relwithdebinfo",
+      "inherits": [
+        "linux-clang-base",
+        "ninja",
+        "relwithdebinfo",
+        "xad-base"
+      ]
+    },
+    {
+      "name": "linux-xad-gcc-ninja-debug",
+      "inherits": [
+        "linux-gcc-base",
+        "ninja",
+        "debug",
+        "xad-base"
+      ]
+    },
+    {
+      "name": "linux-xad-gcc-ninja-release",
+      "inherits": [
+        "linux-gcc-base",
+        "ninja",
+        "release",
+        "xad-base"
+      ]
+    },
+    {
+      "name": "linux-xad-gcc-ninja-relwithdebinfo",
+      "inherits": [
+        "linux-gcc-base",
+        "ninja",
+        "relwithdebinfo",
+        "xad-base"
+      ]
+    },
+    {
+      "name": "windows-xad-clang-release",
+      "inherits": [
+        "windows-clang-base",
+        "ninja",
+        "release",
+        "xad-base"
+      ]
+    },
+    {
+      "name": "windows-xad-clang-debug",
+      "inherits": [
+        "windows-clang-base",
+        "ninja",
+        "debug",
+        "xad-base"
+      ]
+    },
+    {
+      "name": "windows-xad-clang-relwithdebinfo",
+      "inherits": [
+        "windows-clang-base",
+        "ninja",
+        "relwithdebinfo",
+        "xad-base"
+      ]
+    },
+    {
+      "name": "windows-xad-msvc-release",
+      "inherits": [
+        "windows-msvc-base",
+        "ninja",
+        "release",
+        "xad-base"
+      ]
+    },
+    {
+      "name": "windows-xad-msvc-debug",
+      "inherits": [
+        "windows-msvc-base",
+        "ninja",
+        "debug",
+        "xad-base"
+      ]
+    },
+    {
+      "name": "windows-xad-msvc-relwithdebinfo",
+      "inherits": [
+        "windows-clang-base",
+        "ninja",
+        "relwithdebinfo",
+        "xad-base"
+      ]
+    }
+  ]
+}

--- a/presets/README.md
+++ b/presets/README.md
@@ -1,8 +1,12 @@
 # CMake User Presets for QuantLib
 
-This folder contains CMake user preset templates for QuantLib integration with XAD.
+This folder contains CMake user preset templates for QuantLib integration with
+XAD, which can be used in addition to the existing `CMakePresets.json` file
+that already ships with QuantLib to add additional presets for Quantlib-XAD.
+(A `CMakeUserPresets.json` can be placed beside the existing `CMakePresets.json` for user-specific local settings and is typically not checked in to Git).
 
-It provides the following extra configure presets for Windows / Visual Studio (all using the Ninja builder for using the built-in CMake support with "Open Folder"):
+It provides the following extra configure presets for Windows / Visual Studio 
+(all using the Ninja builder for using the built-in CMake support with "Open Folder"):
 
 - `windows-xad-msvc-release`
 - `windows-xad-msvc-debug`
@@ -26,13 +30,13 @@ And the following presets for Linux (both for Make and Ninja builders):
 - `linux-xad-gcc-ninja-release`
 - `linux-xad-gcc-ninja-relwithdebinfo`
 
-## Usage 
+## Usage
 
 **When `CMakeUserPresets.json` is not present in QuantLib folder**
 
 If you are not already using a `CMakeUserPresets.json` file with your QuantLib installation,
 you can simply copy to file in this folder into your QuantLib folder as is,
-renaming it to `CMakeUserPresets.json`. 
+renaming it to `CMakeUserPresets.json`.
 
 **When a `CMakeUserPresets.json` is already used**
 
@@ -48,7 +52,7 @@ in the top toolbar.
 
 **Usage with the command line**
 
-On the command-line, configure presets can be selected with the CMake command 
+On the command-line, configure presets can be selected with the CMake command
 as follows (from the QuantLib folder):
 
 ```
@@ -62,8 +66,9 @@ cmake --build .
 **Adjusting Settings**
 
 The top section in the presets file sets the base configuration for using XAD.
-It has the settings for `QL_EXTERNAL_SUBDIRECTORIES` and similar.
-These can be adjusted to your needs, pointing to the relevant folders, etc.
+It has the settings for `QL_EXTERNAL_SUBDIRECTORIES`, etc.
+These can be adjusted to your needs, pointing to the relevant folders
+where you checked out quantlib-xad and XAD.
 
-You can also add settings here about the boost locaton (`BOOST_ROOT`) or other
+You can also add settings here about the boost location (`BOOST_ROOT`) or other
 QuantLib or XAD related CMake settings.

--- a/presets/README.md
+++ b/presets/README.md
@@ -1,0 +1,69 @@
+# CMake User Presets for QuantLib
+
+This folder contains CMake user preset templates for QuantLib integration with XAD.
+
+It provides the following extra configure presets for Windows / Visual Studio (all using the Ninja builder for using the built-in CMake support with "Open Folder"):
+
+- `windows-xad-msvc-release`
+- `windows-xad-msvc-debug`
+- `windows-xad-msvc-relwithdebinfo`
+- `windows-xad-clang-release`
+- `windows-xad-clang-debug`
+- `windows-xad-clang-relwithdebinfo`
+
+And the following presets for Linux (both for Make and Ninja builders):
+
+- `linux-xad-clang-release`
+- `linux-xad-clang-debug`
+- `linux-xad-clang-relwithdebinfo`
+- `linux-xad-gcc-release`
+- `linux-xad-gcc-debug`
+- `linux-xad-gcc-relwithdebinfo`
+- `linux-xad-clang-ninja-debug`
+- `linux-xad-clang-ninja-release`
+- `linux-xad-clang-ninja-relwithdebinfo`
+- `linux-xad-gcc-ninja-debug`
+- `linux-xad-gcc-ninja-release`
+- `linux-xad-gcc-ninja-relwithdebinfo`
+
+## Usage 
+
+**When `CMakeUserPresets.json` is not present in QuantLib folder**
+
+If you are not already using a `CMakeUserPresets.json` file with your QuantLib installation,
+you can simply copy to file in this folder into your QuantLib folder as is,
+renaming it to `CMakeUserPresets.json`. 
+
+**When a `CMakeUserPresets.json` is already used**
+
+Use the file in this folder as a template to adjust your own presets.
+You can copy the presets for XAD that you want to add, along with their
+inherited base presets into you `CMakeUserPresets.json` file in the QuantLib folder.
+
+**Usage with (Visual Studio 2019/2022)**
+
+With Visual Studio, use the "Open Folder" mode to load the QuantLib folder.
+You'll find the XAD CMake settings in the dropdown for configurations
+in the top toolbar.
+
+**Usage with the command line**
+
+On the command-line, configure presets can be selected with the CMake command 
+as follows (from the QuantLib folder):
+
+```
+cmake --preset linux-xad-clang-ninja-release
+cd build/linux-xad-clang-ninja-release
+cmake --build .
+```
+
+(the build folder is set as `build/${presetName}`)
+
+**Adjusting Settings**
+
+The top section in the presets file sets the base configuration for using XAD.
+It has the settings for `QL_EXTERNAL_SUBDIRECTORIES` and similar.
+These can be adjusted to your needs, pointing to the relevant folders, etc.
+
+You can also add settings here about the boost locaton (`BOOST_ROOT`) or other
+QuantLib or XAD related CMake settings.

--- a/test-suite/quantlibtestsuite_xad.cpp
+++ b/test-suite/quantlibtestsuite_xad.cpp
@@ -57,16 +57,6 @@ namespace {
     }
 }
 
-#if defined(QL_ENABLE_SESSIONS)
-namespace QuantLib {
-
-    ThreadKey sessionId() {
-        return {};
-    }
-
-}
-#endif
-
 test_suite* init_unit_test_suite(int, char*[]) {
 
     int argc = boost::unit_test::framework::master_test_suite().argc;


### PR DESCRIPTION
This prepares quantlib-xad for tagging release 1.31 (to match QuantLib's latest release). 

Changes:
- Adds a `CMakeUserPresets.json` file that works with QuantLib 1.31, along with instructions how to use it
- Removes session initialisation from the test file, to match QuantLib's test suite