### PR TITLE
Fix linking with external application after install

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -111,7 +111,8 @@ jobs:
         cd build
         cmake -G Ninja -DBOOST_ROOT=/usr \
           -DCMAKE_BUILD_TYPE=Release \
-          -DCMAKE_PREFIX_PATH=${{ github.workspace }}/install
+          -DCMAKE_PREFIX_PATH=${{ github.workspace }}/install \
+          ..
         cmake --build .
         ./AdjointSwapXAD
 
@@ -203,7 +204,7 @@ jobs:
         mkdir build
         cd build
         call "${{ env.vsvarsall }}" amd64 -vcvars_ver=14.3
-        cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH=${{ github.workspace }}/install
+        cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH=${{ github.workspace }}/install ..
         cmake --build .
         AdjointSwapXAD.exe
 
@@ -287,7 +288,8 @@ jobs:
         cd build
         cmake -G Ninja -DBOOST_ROOT=/usr \
           -DCMAKE_BUILD_TYPE=Release \
-          -DCMAKE_PREFIX_PATH=${{ github.workspace }}/install
+          -DCMAKE_PREFIX_PATH=${{ github.workspace }}/install \
+          ..
         cmake --build .
         ./AdjointSwapXAD
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -201,6 +201,7 @@ jobs:
         echo find_package(QuantLibXad REQUIRED) >> CMakeLists.txt
         echo add_executable(AdjointSwapXAD AdjointSwapXAD.cpp) >> CMakeLists.txt
         echo target_link_libraries(AdjointSwapXAD PRIVATE QuantLib::QuantLib) >> CMakeLists.txt
+        echo set_target_properties(AdjointSwapXAD PROPERTIES MSVC_RUNTIME_LIBRARY MultiThreaded) >> CMakeLists.txt
         mkdir build
         cd build
         call "${{ env.vsvarsall }}" amd64 -vcvars_ver=14.3

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -65,10 +65,19 @@ jobs:
         max-size: 650M
     - name: Configure
       run: |
+        rm -rf ${{ github.workspace }}/install
         cd QuantLib
         mkdir build
         cd build
-        cmake -G Ninja -DBOOST_ROOT=/usr -DQLXAD_DISABLE_AAD=${{ matrix.disable_aad }} -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DQL_EXTERNAL_SUBDIRECTORIES="${{ github.workspace }}/XAD;${{ github.workspace }}/quantlib-xad" -DQL_EXTRA_LINK_LIBRARIES=quantlib-xad -DQL_NULL_AS_FUNCTIONS=ON ..
+        cmake -G Ninja -DBOOST_ROOT=/usr \
+          -DQLXAD_DISABLE_AAD=${{ matrix.disable_aad }} \
+          -DCMAKE_BUILD_TYPE=Release \
+          -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+          -DQL_EXTERNAL_SUBDIRECTORIES="${{ github.workspace }}/XAD;${{ github.workspace }}/quantlib-xad" \
+          -DQL_EXTRA_LINK_LIBRARIES=quantlib-xad \
+          -DQL_NULL_AS_FUNCTIONS=ON \
+          -DCMAKE_INSTALL_PREFIX=${{ github.workspace }}/install \
+          ..
     - name: Compile
       run: |
         cd QuantLib/build
@@ -82,6 +91,31 @@ jobs:
       run: |
         cd QuantLib/build
         ./quantlib-xad/test-suite/quantlib-xad-test-suite --log_level=message
+    - name: Install
+      if: ${{ matrix.disable_aad == 'OFF' }}
+      run: |
+        cd QuantLib/build
+        cmake --install .
+    - name: Test Install
+      if: ${{ matrix.disable_aad == 'OFF' }}
+      run: |
+        mkdir installtest
+        cp qlxad/Examples/AdjointSwap/AdjointSwapXAD.cpp installtest
+        cd installtest
+        echo "cmake_minimum_required(VERSION 3.15.2)" > CMakeLists.txt
+        echo "project(QlTest LANGUAGES CXX)" >> CMakeLists.txt
+        echo "find_package(QuantLibXad REQUIRED)" >> CMakeLists.txt
+        echo "add_executable(AdjointSwapXAD AdjointSwapXAD.cpp)" >> CMakeLists.txt
+        echo "target_link_libraries(AdjointSwapXAD PRIVATE QuantLib::QuantLib)" >> CMakeLists.txt
+        mkdir build
+        cd build
+        cmake -G Ninja -DBOOST_ROOT=/usr \
+          -DCMAKE_BUILD_TYPE=Release \
+          -DCMAKE_PREFIX_PATH=${{ github.workspace }}/install
+        cmake --build .
+        ./AdjointSwapXAD
+
+
 
 
   xad-win:
@@ -127,7 +161,7 @@ jobs:
         mkdir build
         cd build
         call "${{ env.vsvarsall }}" amd64 -vcvars_ver=14.3
-        cmake .. -G Ninja -DQLXAD_DISABLE_AAD=${{ matrix.disable_aad }} -DCMAKE_CXX_COMPILER_LAUNCHER=sccache -DCMAKE_BUILD_TYPE=Release -DQL_EXTERNAL_SUBDIRECTORIES="${{ github.workspace }}/XAD;${{ github.workspace }}/quantlib-xad" -DQL_EXTRA_LINK_LIBRARIES=quantlib-xad -DQL_NULL_AS_FUNCTIONS=ON -DXAD_STATIC_MSVC_RUNTIME=ON
+        cmake .. -G Ninja -DQLXAD_DISABLE_AAD=${{ matrix.disable_aad }} -DCMAKE_CXX_COMPILER_LAUNCHER=sccache -DCMAKE_BUILD_TYPE=Release -DQL_EXTERNAL_SUBDIRECTORIES="${{ github.workspace }}/XAD;${{ github.workspace }}/quantlib-xad" -DQL_EXTRA_LINK_LIBRARIES=quantlib-xad -DQL_NULL_AS_FUNCTIONS=ON -DXAD_STATIC_MSVC_RUNTIME=ON -DCMAKE_INSTALL_PREFIX=${{ github.workspace }}/install
     - name: Build
       shell: cmd
       run: |
@@ -147,6 +181,31 @@ jobs:
         cd QuantLib\build
         call "${{ env.vsvarsall }}" amd64 -vcvars_ver=14.3
         .\quantlib-xad\test-suite\quantlib-xad-test-suite --log_level=message
+    - name: Install
+      if: ${{ matrix.disable_aad == 'OFF' }}
+      run: |
+        cd QuantLib/build
+        cmake --install .
+    - name: Test Install
+      if: ${{ matrix.disable_aad == 'OFF' }}
+      env:
+        BOOST_ROOT: C:\local\boost
+      shell: cmd
+      run: |
+        mkdir installtest
+        copy quantlib-xad\Examples\AdjointSwap\AdjointSwapXAD.cpp installtest
+        cd installtest
+        echo cmake_minimum_required(VERSION 3.15.2) > CMakeLists.txt
+        echo project(QlTest LANGUAGES CXX) >> CMakeLists.txt
+        echo find_package(QuantLibXad REQUIRED) >> CMakeLists.txt
+        echo add_executable(AdjointSwapXAD AdjointSwapXAD.cpp) >> CMakeLists.txt
+        echo target_link_libraries(AdjointSwapXAD PRIVATE QuantLib::QuantLib) >> CMakeLists.txt
+        mkdir build
+        cd build
+        call "${{ env.vsvarsall }}" amd64 -vcvars_ver=14.3
+        cmake -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_PREFIX_PATH=${{ github.workspace }}/install
+        cmake --build .
+        AdjointSwapXAD.exe
 
 
   xad-macos:
@@ -186,7 +245,15 @@ jobs:
         cd QuantLib
         mkdir build
         cd build
-        cmake -G Ninja -DBOOST_ROOT=/usr -DQLXAD_DISABLE_AAD=${{ matrix.disable_aad }} -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DQL_EXTERNAL_SUBDIRECTORIES="${{ github.workspace }}/XAD;${{ github.workspace }}/quantlib-xad" -DQL_EXTRA_LINK_LIBRARIES=quantlib-xad -DQL_NULL_AS_FUNCTIONS=ON ..
+        cmake -G Ninja -DBOOST_ROOT=/usr \
+          -DQLXAD_DISABLE_AAD=${{ matrix.disable_aad }} \
+          -DCMAKE_BUILD_TYPE=Release \
+          -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
+          -DQL_EXTERNAL_SUBDIRECTORIES="${{ github.workspace }}/XAD;${{ github.workspace }}/quantlib-xad" \
+          -DQL_EXTRA_LINK_LIBRARIES=quantlib-xad \
+          -DQL_NULL_AS_FUNCTIONS=ON \
+          -DCMAKE_INSTALL_PREFIX=${{ github.workspace }}/install \
+          ..
     - name: Compile
       run: |
         cd QuantLib/build
@@ -200,6 +267,29 @@ jobs:
       run: |
         cd QuantLib/build
         ./quantlib-xad/test-suite/quantlib-xad-test-suite --log_level=message
+    - name: Install
+      if: ${{ matrix.disable_aad == 'OFF' }}
+      run: |
+        cd QuantLib/build
+        cmake --install .
+    - name: Test Install
+      if: ${{ matrix.disable_aad == 'OFF' }}
+      run: |
+        mkdir installtest
+        cp qlxad/Examples/AdjointSwap/AdjointSwapXAD.cpp installtest
+        cd installtest
+        echo "cmake_minimum_required(VERSION 3.15.2)" > CMakeLists.txt
+        echo "project(QlTest LANGUAGES CXX)" >> CMakeLists.txt
+        echo "find_package(QuantLibXad REQUIRED)" >> CMakeLists.txt
+        echo "add_executable(AdjointSwapXAD AdjointSwapXAD.cpp)" >> CMakeLists.txt
+        echo "target_link_libraries(AdjointSwapXAD PRIVATE QuantLib::QuantLib)" >> CMakeLists.txt
+        mkdir build
+        cd build
+        cmake -G Ninja -DBOOST_ROOT=/usr \
+          -DCMAKE_BUILD_TYPE=Release \
+          -DCMAKE_PREFIX_PATH=${{ github.workspace }}/install
+        cmake --build .
+        ./AdjointSwapXAD
 
   xad-linux-std-classes:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -100,7 +100,7 @@ jobs:
       if: ${{ matrix.disable_aad == 'OFF' }}
       run: |
         mkdir installtest
-        cp qlxad/Examples/AdjointSwap/AdjointSwapXAD.cpp installtest
+        cp quantlib-xad/Examples/AdjointSwap/AdjointSwapXAD.cpp installtest
         cd installtest
         echo "cmake_minimum_required(VERSION 3.15.2)" > CMakeLists.txt
         echo "project(QlTest LANGUAGES CXX)" >> CMakeLists.txt
@@ -276,7 +276,7 @@ jobs:
       if: ${{ matrix.disable_aad == 'OFF' }}
       run: |
         mkdir installtest
-        cp qlxad/Examples/AdjointSwap/AdjointSwapXAD.cpp installtest
+        cp quantlib-xad/Examples/AdjointSwap/AdjointSwapXAD.cpp installtest
         cd installtest
         echo "cmake_minimum_required(VERSION 3.15.2)" > CMakeLists.txt
         echo "project(QlTest LANGUAGES CXX)" >> CMakeLists.txt

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@
 #  QuantLib. XAD is a fast and comprehensive C++ library for
 #  automatic differentiation.
 #
-#  Copyright (C) 2010-2023 Xcelerit Computing Ltd.
+#  Copyright (C) 2010-2024 Xcelerit Computing Ltd.
 #
 #  This program is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU Affero General Public License as published

--- a/cmake/QlXadConfig.cmake.in
+++ b/cmake/QlXadConfig.cmake.in
@@ -1,1 +1,0 @@
-include("${CMAKE_CURRENT_LIST_DIR}/QlXadTargets.cmake")

--- a/cmake/QuantLibXadConfig.cmake.in
+++ b/cmake/QuantLibXadConfig.cmake.in
@@ -1,0 +1,3 @@
+include(CMakeFindDependencyMacro)
+find_dependency(XAD)
+find_dependency(QuantLib)

--- a/ql/CMakeLists.txt
+++ b/ql/CMakeLists.txt
@@ -30,6 +30,7 @@ target_include_directories(quantlib-xad INTERFACE
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/..>
     $<INSTALL_INTERFACE:${QL_INSTALL_INCLUDEDIR}>
 )
+target_compile_features(quantlib-xad INTERFACE cxx_std_14)
 if(NOT QLXAD_DISABLE_AAD)
     target_compile_definitions(quantlib-xad INTERFACE QL_INCLUDE_FIRST=ql/qlxad.hpp)
 else()

--- a/ql/CMakeLists.txt
+++ b/ql/CMakeLists.txt
@@ -5,7 +5,7 @@
 #  QuantLib. XAD is a fast and comprehensive C++ library for
 #  automatic differentiation.
 #
-#  Copyright (C) 2010-2023 Xcelerit Computing Ltd.
+#  Copyright (C) 2010-2024 Xcelerit Computing Ltd.
 #
 #  This program is free software: you can redistribute it and/or modify
 #  it under the terms of the GNU Affero General Public License as published
@@ -40,38 +40,37 @@ if(MSVC)
 endif()
 target_link_libraries(quantlib-xad INTERFACE XAD::xad)
 set_target_properties(quantlib-xad PROPERTIES
-    EXPORT_NAME ${PACKAGE_NAME}
+    EXPORT_NAME QuantLibXad
 )
-install(TARGETS quantlib-xad EXPORT QlXadTargets)
+install(TARGETS quantlib-xad EXPORT QuantLibTargets)
 foreach(file ${QLXAD_HEADERS})
     install(FILES ${file} DESTINATION "${QL_INSTALL_INCLUDEDIR}/ql")
 endforeach()
 
-# Install config scripts and targets
+
+# Install a convenience config script for QuantLibXad, which allows users to
+# 
+# find_package(QuantLibXad REQUIRED)
+# target_link_libraries(myapp PRIVATE QuantLib::QuantLib)
+#
+# That is, it looks for the XAD dependency before it includes the QuantLibConfig file
+#
+# Without that, users have to first find_package(XAD) before find_package(QuantLib)
+# to achieve the same.
+#
+
+set(QLXAD_INSTALL_CMAKEDIR "lib/cmake/QuantLibXad" CACHE STRING
+    "Installation directory for CMake scripts for QuantLib XAD")
+
 include(CMakePackageConfigHelpers)
-write_basic_package_version_file(
-    "${CMAKE_CURRENT_BINARY_DIR}/../cmake/QlXadConfigVersion.cmake"
-    VERSION ${QL_VERSION}
-    COMPATIBILITY AnyNewerVersion
-)
-export(EXPORT QlXadTargets
-    FILE "${CMAKE_CURRENT_BINARY_DIR}/../cmake/QlXadTargets.cmake"
-    NAMESPACE QuantLib::
-)
-configure_file("../cmake/QlXadConfig.cmake.in"
-    "${CMAKE_CURRENT_BINARY_DIR}/../cmake/QlXadConfig.cmake"
+configure_file("../cmake/QuantLibXadConfig.cmake.in"
+    "${PROJECT_BINARY_DIR}/cmake/QuantLibXadConfig.cmake"
     COPYONLY
 )
-configure_package_config_file("../cmake/QlXadConfig.cmake.in"
-    "${CMAKE_CURRENT_BINARY_DIR}/../cmake/QlXadConfig.cmake"
-    INSTALL_DESTINATION "${QL_INSTALL_CMAKEDIR}"
+configure_package_config_file("../cmake/QuantLibXadConfig.cmake.in"
+    "${PROJECT_BINARY_DIR}/cmake/QuantLibXadConfig.cmake"
+    INSTALL_DESTINATION "${QLXAD_INSTALL_CMAKEDIR}"
 )
-install(EXPORT QlXadTargets
-    FILE QlXadTargets.cmake
-    NAMESPACE QuantLib::
-    DESTINATION "${QL_INSTALL_CMAKEDIR}"
-)
-install(FILES "${CMAKE_CURRENT_BINARY_DIR}/../cmake/QlXadConfig.cmake"
-    "${CMAKE_CURRENT_BINARY_DIR}/../cmake/QlXadConfigVersion.cmake"
-    DESTINATION "${QL_INSTALL_CMAKEDIR}"
+install(FILES "${PROJECT_BINARY_DIR}/cmake/QuantLibXadConfig.cmake"
+    DESTINATION "${QLXAD_INSTALL_CMAKEDIR}"
 )

--- a/ql/qlxad.hpp
+++ b/ql/qlxad.hpp
@@ -4,7 +4,7 @@
    QuantLib. XAD is a fast and comprehensive C++ library for
    automatic differentiation.
 
-   Copyright (C) 2010-2023 Xcelerit Computing Ltd.
+   Copyright (C) 2010-2024 Xcelerit Computing Ltd.
 
    This program is free software: you can redistribute it and/or modify
    it under the terms of the GNU Affero General Public License as published


### PR DESCRIPTION
# Description

This PR fixes an outstanding issue about linking a separately developed application against a built and installed QuantLib library with AAD support. The installation exports and flags were previously not set correctly and workarounds for manually adding the required compilation flags were needed. It fixes the issue from #10.

With this PR, after installing a QuantLib-XAD build, external applications can be linked as follows:

```cmake
find_package(QuantLibXad REQUIRED)
add_executable(standalone_application [sources]...)
target_link_libraries(standalone_application PRIVATE QuantLib::QuantLib)
```

This adds the correct link flags and include paths to the build, and also links the XAD library / installation. Note that if `QuantLib` has not been installed into a system prefix in the default CMake search path, `CMAKE_PREFIX_PATH` should be set to put to the installation prefix.

Further, the CI/CD pipelines have been modified on all platforms to include a test for this linking. The library is installed, and a new standalone project is built against this installation.