### PR TITLE
Restore CI triggers for QuantLib master integration

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,8 +20,12 @@
 name: CI
 
 on:
+  repository_dispatch:
+    types: [xad-ci-trigger]
   push:
   pull_request:
+  schedule:
+    - cron: '02 5 * * *'  # 5:02 every day
   workflow_dispatch:
     inputs:
       ql_repo:


### PR DESCRIPTION
## Summary

- Restore `repository_dispatch` trigger (`xad-ci-trigger`) so CI runs when a PR is merged into QuantLib master
- Restore daily `schedule` cron (`5:02 AM UTC`) as a safety net for continuous integration against QuantLib master

These triggers were accidentally removed in commit 98c276b (forge integration, Dec 2025) and never restored.

## Test plan

- [ ] Verify the daily cron triggers a CI run within 24 hours
- [ ] Verify a QuantLib master merge fires the `repository_dispatch` event